### PR TITLE
Make format instance variable to comply with slots.

### DIFF
--- a/rplibs/progressbar/widgets.py
+++ b/rplibs/progressbar/widgets.py
@@ -121,11 +121,11 @@ class ETA(Timer):
 class FileTransferSpeed(Widget):
     'Widget for showing the transfer speed (useful for file transfers).'
 
-    format = '%6.2f %s%s/s'
     prefixes = ' kMGTPEZY'
     __slots__ = ('unit', 'format')
 
-    def __init__(self, unit='B'):
+    def __init__(self, unit='B', format='%6.2f %s%s/s'):
+        self.format = format
         self.unit = unit
 
     def update(self, pbar):


### PR DESCRIPTION
Tested with Python 3.4.
See https://docs.python.org/2/reference/datamodel.html#slots:
"As a result, class attributes cannot be used to set default values for instance variables defined by __slots__; otherwise, the class attribute would overwrite the descriptor assignment."