### PR TITLE
Remove set_empty_loading_screen calls.

### DIFF
--- a/toolkit/pathtracing_reference/run_renderpipeline.py
+++ b/toolkit/pathtracing_reference/run_renderpipeline.py
@@ -25,7 +25,6 @@ class Application(ShowBase):
 
         self.render_pipeline = RenderPipeline()
         self.render_pipeline.mount_mgr.config_dir = "config/"
-        self.render_pipeline.set_empty_loading_screen()
         self.render_pipeline.create(self)
 
         sphere = self.loader.loadModel("res/sphere.bam")

--- a/toolkit/render_service/service.py
+++ b/toolkit/render_service/service.py
@@ -37,7 +37,6 @@ class Application(ShowBase):
         # Construct render pipeline
         self.render_pipeline = RenderPipeline()
         self.render_pipeline.mount_mgr.config_dir = "config/"
-        self.render_pipeline.set_empty_loading_screen()
         self.render_pipeline.create(self)
 
         self.setup_scene()


### PR DESCRIPTION
The "set_empty_loading_screen" method has been removed a while ago.
I tested render_service/service.py. It loads nicely and without a loading screen.