### PR TITLE
Use more efficient set_shader_inputs call

### DIFF
--- a/data/default_cubemap/filter.py
+++ b/data/default_cubemap/filter.py
@@ -75,11 +75,12 @@ class Application(ShowBase):
 
             for i in range(6):
                 node.set_shader(cshader)
-                node.set_shader_input("SourceTex", cubemap)
-                node.set_shader_input("DestTex", dest_cubemap)
-                node.set_shader_input("currentSize", size)
-                node.set_shader_input("currentMip", mipmap)
-                node.set_shader_input("currentFace", i)
+                node.set_shader_inputs(
+                    SourceTex=cubemap,
+                    DestTex=dest_cubemap,
+                    currentSize=size,
+                    currentMip=mipmap,
+                    currentFace=i)
                 attr = node.get_attrib(ShaderAttrib)
                 self.graphicsEngine.dispatch_compute(
                     ( (size + 15) // 16, (size+15) // 16, 1), attr, self.win.gsg)

--- a/rpcore/__init__.py
+++ b/rpcore/__init__.py
@@ -31,3 +31,17 @@ __all__ = ("RenderPipeline", "SpotLight", "PointLight")
 # This file includes all classes from the pipeline which are exposed
 from rpcore.render_pipeline import RenderPipeline
 from rpcore.native import SpotLight, PointLight
+
+# Polyfill a set_shader_inputs function for older versions of Panda.
+from panda3d.core import NodePath
+from direct.extensions_native.extension_native_helpers import Dtool_funcToMethod
+from rplibs.six import iteritems
+
+if not hasattr(NodePath, 'set_shader_inputs'):
+    def set_shader_inputs(self, **inputs):
+        set_shader_input = self.set_shader_input
+        for args in iteritems(inputs):
+            set_shader_input(*args)
+
+    Dtool_funcToMethod(set_shader_inputs, NodePath)
+    del set_shader_inputs

--- a/rpcore/gpu_command_queue.py
+++ b/rpcore/gpu_command_queue.py
@@ -112,5 +112,6 @@ class GPUCommandQueue(RPObject):
         self._command_target = RenderTarget("ExecCommandTarget")
         self._command_target.size = 1, 1
         self._command_target.prepare_buffer()
-        self._command_target.set_shader_input("CommandQueue", self._data_texture)
-        self._command_target.set_shader_input("commandCount", self._pta_num_commands)
+        self._command_target.set_shader_inputs(
+            CommandQueue=self._data_texture,
+            commandCount=self._pta_num_commands)

--- a/rpcore/gui/buffer_viewer.py
+++ b/rpcore/gui/buffer_viewer.py
@@ -240,10 +240,11 @@ class BufferViewer(DraggableWindow):
                 image=stage_tex, w=scale_factor * w, h=scale_factor * h,
                 any_filter=False, parent=node, x=7, y=40, transparent=False)
 
-            preview.set_shader_input("mipmap", 0)
-            preview.set_shader_input("slice", 0)
-            preview.set_shader_input("brightness", 1)
-            preview.set_shader_input("tonemap", False)
+            preview.set_shader_inputs(
+                mipmap=0,
+                slice=0,
+                brightness=1,
+                tonemap=False)
 
             preview_shader = DisplayShaderBuilder.build(
                 stage_tex, scale_factor * w, scale_factor * h)

--- a/rpcore/gui/exposure_widget.py
+++ b/rpcore/gui/exposure_widget.py
@@ -94,7 +94,8 @@ class ExposureWidget(RPObject):
         exposure_tex = stage_mgr.pipes["Exposure"]
         self._cshader = RPLoader.load_shader("/$$rp/shader/visualize_exposure.compute.glsl")
         self._cshader_np.set_shader(self._cshader)
-        self._cshader_np.set_shader_input("DestTex", self._storage_tex)
-        self._cshader_np.set_shader_input("ExposureTex", exposure_tex)
+        self._cshader_np.set_shader_inputs(
+            DestTex=self._storage_tex,
+            ExposureTex=exposure_tex)
 
         return task.done

--- a/rpcore/gui/fps_chart.py
+++ b/rpcore/gui/fps_chart.py
@@ -91,19 +91,21 @@ class FPSChart(RPObject):
 
         self._cshader = RPLoader.load_shader("/$$rp/shader/fps_chart.compute.glsl")
         self._cshader_np.set_shader(self._cshader)
-        self._cshader_np.set_shader_input("DestTex", self._display_tex)
-        self._cshader_np.set_shader_input("FPSValues", self._storage_buffer)
-        self._cshader_np.set_shader_input("index", self._store_index)
-        self._cshader_np.set_shader_input("maxMs", self._chart_ms_max)
+        self._cshader_np.set_shader_inputs(
+            DestTex=self._display_tex,
+            FPSValues=self._storage_buffer,
+            index=self._store_index,
+            maxMs=self._chart_ms_max)
 
         self._update_shader_node = ComputeNode("FPSChartUpdateValues")
         self._update_shader_node.add_dispatch(1, 1, 1)
         self._update_shader_np = self._node.attach_new_node(self._update_shader_node)
         self._ushader = RPLoader.load_shader("/$$rp/shader/fps_chart_update.compute.glsl")
         self._update_shader_np.set_shader(self._ushader)
-        self._update_shader_np.set_shader_input("DestTex", self._storage_buffer)
-        self._update_shader_np.set_shader_input("index", self._store_index)
-        self._update_shader_np.set_shader_input("currentData", self._current_ftime)
+        self._update_shader_np.set_shader_inputs(
+            DestTex=self._storage_buffer,
+            index=self._store_index,
+            currentData=self._current_ftime)
 
         Globals.base.addTask(self._update, "UpdateFPSChart", sort=-50)
 

--- a/rpcore/gui/pipe_viewer.py
+++ b/rpcore/gui/pipe_viewer.py
@@ -146,10 +146,11 @@ class PipeViewer(DraggableWindow):
                     preview_shader = DisplayShaderBuilder.build(pipe_tex, int(w), int(h))
                     preview.set_shader(preview_shader)
 
-                    preview.set_shader_input("mipmap", 0)
-                    preview.set_shader_input("slice", 0)
-                    preview.set_shader_input("brightness", 1)
-                    preview.set_shader_input("tonemap", False)
+                    preview.set_shader_inputs(
+                        mipmap=0,
+                        slice=0,
+                        brightness=1,
+                        tonemap=False)
 
                 if icon_file:
                     Sprite(image=icon_file, parent=node,

--- a/rpcore/gui/sprite.py
+++ b/rpcore/gui/sprite.py
@@ -132,6 +132,10 @@ class Sprite(RPObject):
         """ Sets a shader input on the image """
         self.node.set_shader_input(*args)
 
+    def set_shader_inputs(self, **kwargs):
+        """ Sets multiple shader inputs on the image """
+        self.node.set_shader_inputs(**kwargs)
+
     def remove(self):
         """ Removes the image """
         self.node.remove()

--- a/rpcore/gui/texture_preview.py
+++ b/rpcore/gui/texture_preview.py
@@ -145,10 +145,11 @@ class TexturePreview(DraggableWindow):
             text_size=18, expand_width=90)
         x_pos += 90 + 30
 
-        image.set_shader_input("slice", 0)
-        image.set_shader_input("mipmap", 0)
-        image.set_shader_input("brightness", 1)
-        image.set_shader_input("tonemap", False)
+        image.set_shader_inputs(
+            slice=0,
+            mipmap=0,
+            brightness=1,
+            tonemap=False)
 
         preview_shader = DisplayShaderBuilder.build(tex, display_w, display_h)
         image.set_shader(preview_shader)

--- a/rpcore/render_stage.py
+++ b/rpcore/render_stage.py
@@ -75,6 +75,12 @@ class RenderStage(RPObject):
         for target in itervalues(self._targets):
             target.set_shader_input(*args)
 
+    def set_shader_inputs(self, **kwargs):
+        """ This method sets shader inputs on all stages, which is mainly used
+        by the stage manager """
+        for target in itervalues(self._targets):
+            target.set_shader_inputs(**kwargs)
+
     def update(self):
         """ This method gets called every frame, and can be overridden by render
         stages to perform custom updates """

--- a/rpcore/render_target.py
+++ b/rpcore/render_target.py
@@ -158,6 +158,11 @@ class RenderTarget(RPObject):
         if self.create_default_region:
             self._source_region.set_shader_input(*args, **kwargs)
 
+    def set_shader_inputs(self, **kwargs):
+        """ Sets shader inputs available to the target """
+        if self.create_default_region:
+            self._source_region.set_shader_inputs(**kwargs)
+
     @setter
     def shader(self, shader_obj):
         """ Sets a shader on the target """

--- a/rpcore/stages/collect_used_cells_stage.py
+++ b/rpcore/stages/collect_used_cells_stage.py
@@ -50,8 +50,9 @@ class CollectUsedCellsStage(RenderStage):
         self.cell_list_buffer = Image.create_buffer("CellList", 0, "R32I")
         self.cell_index_buffer = Image.create_2d_array("CellIndices", 0, 0, 0, "R32I")
 
-        self.target.set_shader_input("CellListBuffer", self.cell_list_buffer)
-        self.target.set_shader_input("CellListIndices", self.cell_index_buffer)
+        self.target.set_shader_inputs(
+            CellListBuffer=self.cell_list_buffer,
+            CellListIndices=self.cell_index_buffer)
 
     def update(self):
         self.cell_list_buffer.clear_image()

--- a/rpcore/stages/cull_lights_stage.py
+++ b/rpcore/stages/cull_lights_stage.py
@@ -93,19 +93,23 @@ class CullLightsStage(RenderStage):
         self.grouped_cell_lights_counts = Image.create_buffer(
             "GroupedPerCellLightsCount", 0, "R16UI")
 
-        self.target_visible.set_shader_input("FrustumLights", self.frustum_lights)
-        self.target_visible.set_shader_input("FrustumLightsCount", self.frustum_lights_ctr)
-        self.target_cull.set_shader_input("PerCellLightsBuffer", self.per_cell_lights)
-        self.target_cull.set_shader_input("PerCellLightCountsBuffer", self.per_cell_light_counts)
-        self.target_cull.set_shader_input("FrustumLights", self.frustum_lights)
-        self.target_cull.set_shader_input("FrustumLightsCount", self.frustum_lights_ctr)
-        self.target_group.set_shader_input("PerCellLightsBuffer", self.per_cell_lights)
-        self.target_group.set_shader_input("PerCellLightCountsBuffer", self.per_cell_light_counts)
-        self.target_group.set_shader_input("GroupedCellLightsBuffer", self.grouped_cell_lights)
-        self.target_group.set_shader_input("GroupedPerCellLightsCountBuffer", self.grouped_cell_lights_counts)
+        self.target_visible.set_shader_inputs(
+            FrustumLights=self.frustum_lights,
+            FrustumLightsCount=self.frustum_lights_ctr)
 
-        self.target_cull.set_shader_input("threadCount", self.cull_threads)
-        self.target_group.set_shader_input("threadCount", 1)
+        self.target_cull.set_shader_inputs(
+            PerCellLightsBuffer=self.per_cell_lights,
+            PerCellLightCountsBuffer=self.per_cell_light_counts,
+            FrustumLights=self.frustum_lights,
+            FrustumLightsCount=self.frustum_lights_ctr,
+            threadCount=self.cull_threads)
+
+        self.target_group.set_shader_inputs(
+            PerCellLightsBuffer=self.per_cell_lights,
+            PerCellLightCountsBuffer=self.per_cell_light_counts,
+            GroupedCellLightsBuffer=self.grouped_cell_lights,
+            GroupedPerCellLightsCountBuffer=self.grouped_cell_lights_counts,
+            threadCount=1)
 
     def reload_shaders(self):
         self.target_cull.shader = self.load_shader(

--- a/rpcore/stages/gbuffer_stage.py
+++ b/rpcore/stages/gbuffer_stage.py
@@ -61,3 +61,6 @@ class GBufferStage(RenderStage):
 
     def set_shader_input(self, *args):
         Globals.render.set_shader_input(*args)
+
+    def set_shader_inputs(self, **kwargs):
+        Globals.render.set_shader_inputs(**kwargs)

--- a/rpcore/stages/shadow_stage.py
+++ b/rpcore/stages/shadow_stage.py
@@ -73,3 +73,6 @@ class ShadowStage(RenderStage):
 
     def set_shader_input(self, *args):
         Globals.render.set_shader_input(*args)
+
+    def set_shader_inputs(self, **kwargs):
+        Globals.render.set_shader_inputs(**kwargs)

--- a/rpcore/util/cubemap_filter.py
+++ b/rpcore/util/cubemap_filter.py
@@ -134,8 +134,9 @@ class CubemapFilter(RPObject):
             target_filter = self._stage.create_target("CF:SpecIBL-PostFilter-" + str(mipsize))
             target_filter.size = mipsize * 6, mipsize
             target_filter.prepare_buffer()
-            target_filter.set_shader_input("currentMip", mip)
-            target_filter.set_shader_input("SourceTex", self._spec_pref_map)
+            target_filter.set_shader_inputs(
+                currentMip=mip,
+                SourceTex=self._spec_pref_map)
             target_filter.set_shader_input(
                 "DestMipmap", self._specular_map, False, True, -1, mip, 0)
 
@@ -152,9 +153,10 @@ class CubemapFilter(RPObject):
             CubemapFilter.PREFILTER_CUBEMAP_SIZE)
         self._diffuse_target.prepare_buffer()
 
-        self._diffuse_target.set_shader_input("SourceCubemap", self._specular_map)
-        self._diffuse_target.set_shader_input("DestCubemap", self._prefilter_map)
-        self._diffuse_target.set_shader_input("cubeSize", CubemapFilter.PREFILTER_CUBEMAP_SIZE)
+        self._diffuse_target.set_shader_inputs(
+            SourceCubemap=self._specular_map,
+            DestCubemap=self._prefilter_map,
+            cubeSize=CubemapFilter.PREFILTER_CUBEMAP_SIZE)
 
         # Create the target which removes the noise from the previous target,
         # which is introduced with importance sampling
@@ -164,9 +166,10 @@ class CubemapFilter(RPObject):
             CubemapFilter.DIFFUSE_CUBEMAP_SIZE)
         self._diff_filter_target.prepare_buffer()
 
-        self._diff_filter_target.set_shader_input("SourceCubemap", self._prefilter_map)
-        self._diff_filter_target.set_shader_input("DestCubemap", self._diffuse_map)
-        self._diff_filter_target.set_shader_input("cubeSize", CubemapFilter.DIFFUSE_CUBEMAP_SIZE)
+        self._diff_filter_target.set_shader_inputs(
+            SourceCubemap=self._prefilter_map,
+            DestCubemap=self._diffuse_map,
+            cubeSize=CubemapFilter.DIFFUSE_CUBEMAP_SIZE)
 
     def reload_shaders(self):
         """ Sets all required shaders on the filter. """

--- a/rpcore/util/post_process_region.py
+++ b/rpcore/util/post_process_region.py
@@ -94,6 +94,9 @@ class PostProcessRegion(RPObject):
         else:
             self._tri.set_shader_input(*args)
 
+    def set_shader_inputs(self, **kwargs):
+        self._tri.set_shader_inputs(**kwargs)
+
     def _make_fullscreen_cam(self):
         """ Creates an orthographic camera for the buffer """
         buffer_cam = Camera("BufferCamera")

--- a/rpplugins/ao/ao_stage.py
+++ b/rpplugins/ao/ao_stage.py
@@ -48,8 +48,9 @@ class AOStage(RenderStage):
         self.target_upscale.add_color_attachment(bits=(8, 0, 0, 0))
         self.target_upscale.prepare_buffer()
 
-        self.target_upscale.set_shader_input("SourceTex", self.target.color_tex)
-        self.target_upscale.set_shader_input("upscaleWeights", Vec2(0.001, 0.001))
+        self.target_upscale.set_shader_inputs(
+            SourceTex=self.target.color_tex,
+            upscaleWeights=Vec2(0.001, 0.001))
 
         self.tarrget_detail_ao = self.create_target("DetailAO")
         self.tarrget_detail_ao.add_color_attachment(bits=(8, 0, 0, 0))
@@ -85,14 +86,15 @@ class AOStage(RenderStage):
             target_blur_h.add_color_attachment(bits=(8, 0, 0, 0))
             target_blur_h.prepare_buffer()
 
-            target_blur_v.set_shader_input("SourceTex", current_tex)
-            target_blur_h.set_shader_input("SourceTex", target_blur_v.color_tex)
+            target_blur_v.set_shader_inputs(
+                SourceTex=current_tex,
+                blur_direction=LVecBase2i(0, 1),
+                pixel_stretch=pixel_stretch)
 
-            target_blur_v.set_shader_input("blur_direction", LVecBase2i(0, 1))
-            target_blur_h.set_shader_input("blur_direction", LVecBase2i(1, 0))
-
-            target_blur_v.set_shader_input("pixel_stretch", pixel_stretch)
-            target_blur_h.set_shader_input("pixel_stretch", pixel_stretch)
+            target_blur_h.set_shader_inputs(
+                SourceTex=target_blur_v.color_tex,
+                blur_direction=LVecBase2i(1, 0),
+                pixel_stretch=pixel_stretch)
 
             current_tex = target_blur_h.color_tex
             self.blur_targets += [target_blur_v, target_blur_h]

--- a/rpplugins/bloom/bloom_stage.py
+++ b/rpplugins/bloom/bloom_stage.py
@@ -78,8 +78,9 @@ class BloomStage(RenderStage):
             target = self.create_target("Downsample:Step-" + str(i))
             target.size = -scale_multiplier, -scale_multiplier
             target.prepare_buffer()
-            target.set_shader_input("sourceMip", i)
-            target.set_shader_input("SourceTex", self.scene_target_img)
+            target.set_shader_inputs(
+                sourceMip=i,
+                SourceTex=self.scene_target_img)
             target.set_shader_input("DestTex", self.scene_target_img, False, True, -1, i + 1)
             self.downsample_targets.append(target)
 
@@ -89,10 +90,10 @@ class BloomStage(RenderStage):
             target = self.create_target("Upsample:Step-" + str(i))
             target.size = -scale_multiplier, -scale_multiplier
             target.prepare_buffer()
-            target.set_shader_input("FirstUpsamplePass", i == 0)
-
-            target.set_shader_input("sourceMip", self.num_mips - i)
-            target.set_shader_input("SourceTex", self.scene_target_img)
+            target.set_shader_inputs(
+                FirstUpsamplePass=(i==0),
+                sourceMip=(self.num_mips - i),
+                SourceTex=self.scene_target_img)
             target.set_shader_input("DestTex", self.scene_target_img,
                                     False, True, -1, self.num_mips - i - 1)
             self.upsample_targets.append(target)

--- a/rpplugins/clouds/apply_clouds_stage.py
+++ b/rpplugins/clouds/apply_clouds_stage.py
@@ -51,8 +51,9 @@ class ApplyCloudsStage(RenderStage):
         self.upscale_target = self.create_target("UpscaleTarget")
         self.upscale_target.add_color_attachment(bits=16, alpha=True)
         self.upscale_target.prepare_buffer()
-        self.upscale_target.set_shader_input("upscaleWeights", Vec2(0.05, 0.2))
-        self.upscale_target.set_shader_input("SourceTex", self.render_target.color_tex)
+        self.upscale_target.set_shader_inputs(
+            upscaleWeights=Vec2(0.05, 0.2),
+            SourceTex=self.render_target.color_tex)
 
         self.target_apply_clouds = self.create_target("MergeWithScene")
         self.target_apply_clouds.add_color_attachment(bits=16)

--- a/rpplugins/clouds/cloud_voxel_stage.py
+++ b/rpplugins/clouds/cloud_voxel_stage.py
@@ -73,8 +73,9 @@ class CloudVoxelStage(RenderStage):
         self._shade_target.size = self._voxel_res_xy, self._voxel_res_xy
         self._shade_target.prepare_buffer()
         self._shade_target.quad.set_instance_count(self._voxel_res_z)
-        self._shade_target.set_shader_input("CloudVoxels", self._cloud_voxels)
-        self._shade_target.set_shader_input("CloudVoxelsDest", self._cloud_voxels)
+        self._shade_target.set_shader_inputs(
+            CloudVoxels=self._cloud_voxels,
+            CloudVoxelsDest=self._cloud_voxels)
 
     def reload_shaders(self):
         self._grid_target.shader = self.load_plugin_shader(

--- a/rpplugins/dof/dof_stage.py
+++ b/rpplugins/dof/dof_stage.py
@@ -68,16 +68,18 @@ class DoFStage(RenderStage):
         self.presort_target = self.create_target("DoFPresort")
         self.presort_target.add_color_attachment(bits=(11, 11, 10))
         self.presort_target.prepare_buffer()
-        self.presort_target.set_shader_input("TileMinMax", self.minmax_target.color_tex)
-        self.presort_target.set_shader_input("PrecomputedCoC", self.target_prefilter.color_tex)
+        self.presort_target.set_shader_inputs(
+            TileMinMax=self.minmax_target.color_tex,
+            PrecomputedCoC=self.target_prefilter.color_tex)
 
         self.target = self.create_target("ComputeDoF")
         # self.target.size = -2
         self.target.add_color_attachment(bits=16, alpha=True)
         self.target.prepare_buffer()
-        self.target.set_shader_input("PresortResult", self.presort_target.color_tex)
-        self.target.set_shader_input("PrecomputedCoC", self.target_prefilter.color_tex)
-        self.target.set_shader_input("TileMinMax", self.minmax_target.color_tex)
+        self.target.set_shader_inputs(
+            PresortResult=self.presort_target.color_tex,
+            PrecomputedCoC=self.target_prefilter.color_tex,
+            TileMinMax=self.minmax_target.color_tex)
 
         self.target_merge = self.create_target("MergeDoF")
         self.target_merge.add_color_attachment(bits=16)

--- a/rpplugins/env_probes/cull_probes_stage.py
+++ b/rpplugins/env_probes/cull_probes_stage.py
@@ -59,8 +59,9 @@ class CullProbesStage(RenderStage):
 
         self.per_cell_probes = Image.create_buffer("PerCellProbes", 0, "R32I")
         self.per_cell_probes.clear_image()
-        self.target.set_shader_input("PerCellProbes", self.per_cell_probes)
-        self.target.set_shader_input("threadCount", 1)
+        self.target.set_shader_inputs(
+            PerCellProbes=self.per_cell_probes,
+            threadCount=1)
 
     def set_dimensions(self):
         max_cells = self._pipeline.light_mgr.total_tiles

--- a/rpplugins/env_probes/environment_capture_stage.py
+++ b/rpplugins/env_probes/environment_capture_stage.py
@@ -113,17 +113,19 @@ class EnvironmentCaptureStage(RenderStage):
         self.target_store = self.create_target("StoreCubemap")
         self.target_store.size = self.resolution * 6, self.resolution
         self.target_store.prepare_buffer()
-        self.target_store.set_shader_input("SourceTex", self.target.color_tex)
-        self.target_store.set_shader_input("DestTex", self.storage_tex)
-        self.target_store.set_shader_input("currentIndex", self.pta_index)
+        self.target_store.set_shader_inputs(
+            SourceTex=self.target.color_tex,
+            DestTex=self.storage_tex,
+            currentIndex=self.pta_index)
 
         self.temporary_diffuse_map = Image.create_cube("DiffuseTemp", self.resolution, "RGBA16")
         self.target_store_diff = self.create_target("StoreCubemapDiffuse")
         self.target_store_diff.size = self.resolution * 6, self.resolution
         self.target_store_diff.prepare_buffer()
-        self.target_store_diff.set_shader_input("SourceTex", self.target.color_tex)
-        self.target_store_diff.set_shader_input("DestTex", self.temporary_diffuse_map)
-        self.target_store_diff.set_shader_input("currentIndex", self.pta_index)
+        self.target_store_diff.set_shader_inputs(
+            SourceTex=self.target.color_tex,
+            DestTex=self.temporary_diffuse_map,
+            currentIndex=self.pta_index)
 
     def _create_filter_targets(self):
         """ Generates the targets which filter the specular cubemap """
@@ -136,9 +138,10 @@ class EnvironmentCaptureStage(RenderStage):
             target = self.create_target("FilterCubemap:{0}-{1}x{1}".format(mip, size))
             target.size = size * 6, size
             target.prepare_buffer()
-            target.set_shader_input("currentIndex", self.pta_index)
-            target.set_shader_input("currentMip", mip)
-            target.set_shader_input("SourceTex", self.storage_tex)
+            target.set_shader_inputs(
+                currentIndex=self.pta_index,
+                currentMip=mip,
+                SourceTex=self.storage_tex)
             target.set_shader_input("DestTex", self.storage_tex, False, True, -1, mip, 0)
             self.filter_targets.append(target)
 
@@ -146,9 +149,10 @@ class EnvironmentCaptureStage(RenderStage):
         self.filter_diffuse_target = self.create_target("FilterCubemapDiffuse")
         self.filter_diffuse_target.size = self.diffuse_resolution * 6, self.diffuse_resolution
         self.filter_diffuse_target.prepare_buffer()
-        self.filter_diffuse_target.set_shader_input("SourceTex", self.temporary_diffuse_map)
-        self.filter_diffuse_target.set_shader_input("DestTex", self.storage_tex_diffuse)
-        self.filter_diffuse_target.set_shader_input("currentIndex", self.pta_index)
+        self.filter_diffuse_target.set_shader_inputs(
+            SourceTex=self.temporary_diffuse_map,
+            DestTex=self.storage_tex_diffuse,
+            currentIndex=self.pta_index)
 
     def set_probe(self, probe):
         self.rig_node.set_mat(probe.matrix)
@@ -174,6 +178,9 @@ class EnvironmentCaptureStage(RenderStage):
 
     def set_shader_input(self, *args):
         Globals.render.set_shader_input(*args)
+
+    def set_shader_inputs(self, **kwargs):
+        Globals.render.set_shader_inputs(**kwargs)
 
     def reload_shaders(self):
         self.target_store.shader = self.load_plugin_shader(

--- a/rpplugins/forward_shading/forward_stage.py
+++ b/rpplugins/forward_shading/forward_stage.py
@@ -58,12 +58,17 @@ class ForwardStage(RenderStage):
         self.target_merge = self.create_target("MergeWithDeferred")
         self.target_merge.add_color_attachment(bits=16)
         self.target_merge.prepare_buffer()
-        self.target_merge.set_shader_input("ForwardDepth", self.target.depth_tex)
-        self.target_merge.set_shader_input("ForwardColor", self.target.color_tex)
+        self.target_merge.set_shader_inputs(
+            ForwardDepth=self.target.depth_tex,
+            ForwardColor=self.target.color_tex)
 
     def set_shader_input(self, *args):
         Globals.base.render.set_shader_input(*args)
         RenderStage.set_shader_input(self, *args)
+
+    def set_shader_inputs(self, **kwargs):
+        Globals.base.render.set_shader_inputs(**kwargs)
+        RenderStage.set_shader_inputs(self, **kwargs)
 
     def reload_shaders(self):
         self.target_merge.shader = self.load_plugin_shader("merge_with_deferred.frag.glsl")

--- a/rpplugins/motion_blur/motion_blur_stage.py
+++ b/rpplugins/motion_blur/motion_blur_stage.py
@@ -67,8 +67,9 @@ class MotionBlurStage(RenderStage):
             self.target = self.create_target("ObjectMotionBlur")
             self.target.add_color_attachment(bits=16)
             self.target.prepare_buffer()
-            self.target.set_shader_input("NeighborMinMax", self.minmax_target.color_tex)
-            self.target.set_shader_input("PackedSceneData", self.pack_target.color_tex)
+            self.target.set_shader_inputs(
+                NeighborMinMax=self.minmax_target.color_tex,
+                PackedSceneData=self.pack_target.color_tex)
 
             self.target.color_tex.set_wrap_u(SamplerState.WM_clamp)
             self.target.color_tex.set_wrap_v(SamplerState.WM_clamp)

--- a/rpplugins/pssm/plugin.py
+++ b/rpplugins/pssm/plugin.py
@@ -110,13 +110,15 @@ class Plugin(BasePlugin):
         Globals.base.accept("u", self.toggle_update_enabled)
 
         # Set inputs
-        self.pssm_stage.set_shader_input("pssm_mvps", self.camera_rig.get_mvp_array())
-        self.pssm_stage.set_shader_input("pssm_nearfar", self.camera_rig.get_nearfar_array())
+        self.pssm_stage.set_shader_inputs(
+            pssm_mvps=self.camera_rig.get_mvp_array(),
+            pssm_nearfar=self.camera_rig.get_nearfar_array())
 
         if self.is_plugin_enabled("volumetrics"):
             handle = self.get_plugin_instance("volumetrics")
-            handle.stage.set_shader_input("pssm_mvps", self.camera_rig.get_mvp_array())
-            handle.stage.set_shader_input("pssm_nearfar", self.camera_rig.get_nearfar_array())
+            handle.stage.set_shader_inputs(
+                pssm_mvps=self.camera_rig.get_mvp_array(),
+                pssm_nearfar=self.camera_rig.get_nearfar_array())
 
 
     def on_pre_render_update(self):

--- a/rpplugins/pssm/pssm_dist_shadow_stage.py
+++ b/rpplugins/pssm/pssm_dist_shadow_stage.py
@@ -113,15 +113,17 @@ class PSSMDistShadowStage(RenderStage):
         self.target_blur_v.size = self.resolution
         self.target_blur_v.add_color_attachment(bits=(32, 0, 0, 0))
         self.target_blur_v.prepare_buffer()
-        self.target_blur_v.set_shader_input("SourceTex", self.target_convert.color_tex)
-        self.target_blur_v.set_shader_input("direction", LVecBase2i(1, 0))
+        self.target_blur_v.set_shader_inputs(
+            SourceTex=self.target_convert.color_tex,
+            direction=LVecBase2i(1, 0))
 
         self.target_blur_h = self.create_target("BlurHoriz")
         self.target_blur_h.size = self.resolution
         self.target_blur_h.add_color_attachment(bits=(32, 0, 0, 0))
         self.target_blur_h.prepare_buffer()
-        self.target_blur_h.set_shader_input("SourceTex", self.target_blur_v.color_tex)
-        self.target_blur_h.set_shader_input("direction", LVecBase2i(0, 1))
+        self.target_blur_h.set_shader_inputs(
+            SourceTex=self.target_blur_v.color_tex,
+            direction=LVecBase2i(0, 1))
 
         # Register shadow camera
         self._pipeline.tag_mgr.register_camera("shadow", self.camera)
@@ -133,3 +135,6 @@ class PSSMDistShadowStage(RenderStage):
 
     def set_shader_input(self, *args):
         Globals.render.set_shader_input(*args)
+
+    def set_shader_inputs(self, **kwargs):
+        Globals.render.set_shader_inputs(**kwargs)

--- a/rpplugins/pssm/pssm_scene_shadow_stage.py
+++ b/rpplugins/pssm/pssm_scene_shadow_stage.py
@@ -116,3 +116,6 @@ class PSSMSceneShadowStage(RenderStage):
 
     def set_shader_input(self, *args):
         Globals.render.set_shader_input(*args)
+
+    def set_shader_inputs(self, **kwargs):
+        Globals.render.set_shader_inputs(**kwargs)

--- a/rpplugins/pssm/pssm_shadow_stage.py
+++ b/rpplugins/pssm/pssm_shadow_stage.py
@@ -88,3 +88,6 @@ class PSSMShadowStage(RenderStage):
 
     def set_shader_input(self, *args):
         Globals.render.set_shader_input(*args)
+
+    def set_shader_inputs(self, **kwargs):
+        Globals.render.set_shader_inputs(**kwargs)

--- a/rpplugins/scattering/scattering_methods.py
+++ b/rpplugins/scattering/scattering_methods.py
@@ -150,8 +150,7 @@ class ScatteringMethodEricBruneton(ScatteringMethod):
 
         nodepath = NodePath("shader")
         nodepath.set_shader(shader_obj)
-        for key, val in iteritems(shader_inputs):
-            nodepath.set_shader_input(key, val)
+        nodepath.set_shader_inputs(**shader_inputs)
 
         attr = nodepath.get_attrib(ShaderAttrib)
         Globals.base.graphicsEngine.dispatch_compute(
@@ -249,6 +248,7 @@ class ScatteringMethodEricBruneton(ScatteringMethod):
 
         # Make stages available
         for stage in [self.handle.display_stage, self.handle.envmap_stage]:
-            stage.set_shader_input("InscatterSampler", self.textures["inscatter"])
-            stage.set_shader_input("transmittanceSampler", self.textures["transmittance"])
-            stage.set_shader_input("IrradianceSampler", self.textures["irradiance"])
+            stage.set_shader_inputs(
+                InscatterSampler=self.textures["inscatter"],
+                transmittanceSampler=self.textures["transmittance"],
+                IrradianceSampler=self.textures["irradiance"])

--- a/rpplugins/sky_ao/ao_stage.py
+++ b/rpplugins/sky_ao/ao_stage.py
@@ -51,8 +51,9 @@ class SkyAOStage(RenderStage):
         self.target_upscale.add_color_attachment(bits=(16, 0, 0, 0))
         self.target_upscale.prepare_buffer()
 
-        self.target_upscale.set_shader_input("SourceTex", self.target.color_tex)
-        self.target_upscale.set_shader_input("upscaleWeights", Vec2(0.001, 0.001))
+        self.target_upscale.set_shader_inputs(
+            SourceTex=self.target.color_tex,
+            upscaleWeights=Vec2(0.001, 0.001))
 
     def reload_shaders(self):
         self.target.shader = self.load_plugin_shader(

--- a/rpplugins/sky_ao/capture_stage.py
+++ b/rpplugins/sky_ao/capture_stage.py
@@ -74,8 +74,9 @@ class SkyAOCaptureStage(RenderStage):
         self.target_convert.add_color_attachment(bits=(16, 0, 0, 0))
         self.target_convert.prepare_buffer()
 
-        self.target_convert.set_shader_input("DepthTex", self.target.depth_tex)
-        self.target_convert.set_shader_input("position", self.pta_position)
+        self.target_convert.set_shader_inputs(
+            DepthTex=self.target.depth_tex,
+            position=self.pta_position)
 
         # Register camera
         self._pipeline.tag_mgr.register_camera("shadow", self.camera)

--- a/rpplugins/smaa/smaa_stage.py
+++ b/rpplugins/smaa/smaa_stage.py
@@ -76,10 +76,11 @@ class SMAAStage(RenderStage):
         self.blend_target.add_color_attachment(alpha=True)
         self.blend_target.prepare_buffer()
 
-        self.blend_target.set_shader_input("EdgeTex", self.edge_target.color_tex)
-        self.blend_target.set_shader_input("AreaTex", self.area_tex)
-        self.blend_target.set_shader_input("SearchTex", self.search_tex)
-        self.blend_target.set_shader_input("jitterIndex", self._jitter_index)
+        self.blend_target.set_shader_inputs(
+            EdgeTex=self.edge_target.color_tex,
+            AreaTex=self.area_tex,
+            SearchTex=self.search_tex,
+            jitterIndex=self._jitter_index)
 
         # Neighbor blending
         self.neighbor_target = self.create_target("NeighborBlending")
@@ -92,10 +93,10 @@ class SMAAStage(RenderStage):
             self.resolve_target = self.create_target("Resolve")
             self.resolve_target.add_color_attachment(bits=16)
             self.resolve_target.prepare_buffer()
-            self.resolve_target.set_shader_input("jitterIndex", self._jitter_index)
-
-            # Set initial textures
-            self.resolve_target.set_shader_input("CurrentTex", self.neighbor_target.color_tex)
+            self.resolve_target.set_shader_inputs(
+                jitterIndex=self._jitter_index,
+                # Set initial textures
+                CurrentTex=self.neighbor_target.color_tex)
 
     def reload_shaders(self):
         self.edge_target.shader = self.load_plugin_shader("edge_detection.frag.glsl")

--- a/rpplugins/ssr/ssr_stage.py
+++ b/rpplugins/ssr/ssr_stage.py
@@ -64,15 +64,16 @@ class SSRStage(RenderStage):
         self.target_upscale = self.create_target("UpscaleSSR")
         self.target_upscale.add_color_attachment(bits=16, alpha=True)
         self.target_upscale.prepare_buffer()
-        self.target_upscale.set_shader_input("SourceTex", self.target.color_tex)
-        self.target_upscale.set_shader_input(
-            "LastFrameColor", self.target_reproject_lighting.color_tex)
+        self.target_upscale.set_shader_inputs(
+            SourceTex=self.target.color_tex,
+            LastFrameColor=self.target_reproject_lighting.color_tex)
 
         self.target_resolve = self.create_target("ResolveSSR")
         self.target_resolve.add_color_attachment(bits=16, alpha=True)
         self.target_resolve.prepare_buffer()
-        self.target_resolve.set_shader_input("CurrentTex", self.target_upscale.color_tex)
-        self.target_resolve.set_shader_input("VelocityTex", self.target_velocity.color_tex)
+        self.target_resolve.set_shader_inputs(
+            CurrentTex=self.target_upscale.color_tex,
+            VelocityTex=self.target_velocity.color_tex)
 
         AmbientStage.required_pipes.append("SSRSpecular")
 

--- a/rpplugins/volumetrics/volumetrics_stage.py
+++ b/rpplugins/volumetrics/volumetrics_stage.py
@@ -55,8 +55,9 @@ class VolumetricsStage(RenderStage):
             self.target_upscale.add_color_attachment(bits=16, alpha=True)
             self.target_upscale.prepare_buffer()
 
-            self.target_upscale.set_shader_input("SourceTex", self.target.color_tex)
-            self.target_upscale.set_shader_input("upscaleWeights", Vec2(0.001, 0.001))
+            self.target_upscale.set_shader_inputs(
+                SourceTex=self.target.color_tex,
+                upscaleWeights=Vec2(0.001, 0.001))
 
         self.target_combine = self.create_target("CombineVolumetrics")
         self.target_combine.add_color_attachment(bits=16)

--- a/rpplugins/vxgi/voxelization_stage.py
+++ b/rpplugins/vxgi/voxelization_stage.py
@@ -112,8 +112,9 @@ class VoxelizationStage(RenderStage):
         # TODO! Does not work with the new render target yet - maybe add option
         # to post process region for instances?
         self.copy_target.instance_count = self.voxel_resolution
-        self.copy_target.set_shader_input("SourceTex", self.voxel_temp_grid)
-        self.copy_target.set_shader_input("DestTex", self.voxel_grid)
+        self.copy_target.set_shader_inputs(
+            SourceTex=self.voxel_temp_grid,
+            DestTex=self.voxel_grid)
 
         # Create the target which generates the mipmaps
         self.mip_targets = []
@@ -124,8 +125,9 @@ class VoxelizationStage(RenderStage):
             mip_target.size = mip_size
             mip_target.prepare_buffer()
             mip_target.instance_count = mip_size
-            mip_target.set_shader_input("SourceTex", self.voxel_grid)
-            mip_target.set_shader_input("sourceMip", mip - 1)
+            mip_target.set_shader_inputs(
+                SourceTex=self.voxel_grid,
+                sourceMip=(mip - 1))
             mip_target.set_shader_input("DestTex", self.voxel_grid, False, True, -1, mip, 0)
             self.mip_targets.append(mip_target)
 
@@ -136,8 +138,9 @@ class VoxelizationStage(RenderStage):
         initial_state.set_attrib(ColorWriteAttrib.make(ColorWriteAttrib.C_off), 100000)
         self.voxel_cam.set_initial_state(initial_state.get_state())
 
-        Globals.base.render.set_shader_input("voxelGridPosition", self.pta_next_grid_pos)
-        Globals.base.render.set_shader_input("VoxelGridDest", self.voxel_temp_grid)
+        Globals.base.render.set_shader_inputs(
+            voxelGridPosition=self.pta_next_grid_pos,
+            VoxelGridDest=self.voxel_temp_grid)
 
     def update(self):
         self.voxel_cam_np.show()
@@ -195,3 +198,6 @@ class VoxelizationStage(RenderStage):
 
     def set_shader_input(self, *args):
         Globals.render.set_shader_input(*args)
+
+    def set_shader_inputs(self, **kwargs):
+        Globals.render.set_shader_inputs(**kwargs)

--- a/rpplugins/vxgi/vxgi_stage.py
+++ b/rpplugins/vxgi/vxgi_stage.py
@@ -81,8 +81,9 @@ class VXGIStage(RenderStage):
         self.target_upscale_diff = self.create_target("UpscaleDiffuse")
         self.target_upscale_diff.add_color_attachment(bits=16)
         self.target_upscale_diff.prepare_buffer()
-        self.target_upscale_diff.set_shader_input("SourceTex", self.target_blur_h.color_tex)
-        self.target_upscale_diff.set_shader_input("upscaleWeights", Vec2(0.0001, 0.001))
+        self.target_upscale_diff.set_shader_inputs(
+            SourceTex=self.target_blur_h.color_tex,
+            upscaleWeights=Vec2(0.0001, 0.001))
 
         self.target_resolve = self.create_target("ResolveVXGI")
         self.target_resolve.add_color_attachment(bits=16)

--- a/toolkit/bake_gi/bake.py
+++ b/toolkit/bake_gi/bake.py
@@ -163,8 +163,9 @@ class Application(ShowBase):
             target_store_cubemap = RenderTarget()
             target_store_cubemap.size = capture_resolution * 6, capture_resolution
             target_store_cubemap.prepare_buffer()
-            target_store_cubemap.set_shader_input("SourceTex", capture_target.color_tex)
-            target_store_cubemap.set_shader_input("DestTex", destination_cubemap)
+            target_store_cubemap.set_shader_inputs(
+                SourceTex=capture_target.color_tex,
+                DestTex=destination_cubemap)
 
             target_store_cubemap.shader = store_shader
 
@@ -174,18 +175,20 @@ class Application(ShowBase):
             target_convolute.size = 6, 1
             # target_convolute.add_color_attachment(bits=16)
             target_convolute.prepare_buffer()
-            target_convolute.set_shader_input("SourceTex", destination_cubemap)
-            target_convolute.set_shader_input("DestTex", final_data)
-            target_convolute.set_shader_input("storeCoord", store_pta)
+            target_convolute.set_shader_inputs(
+                SourceTex=destination_cubemap,
+                DestTex=final_data,
+                storeCoord=store_pta)
             target_convolute.shader = convolute_shader
 
             # Set initial shader
             shader = Shader.load(Shader.SL_GLSL,
                 "resources/first-bounce.vert.glsl", "resources/first-bounce.frag.glsl")
             render.set_shader(shader)
-            render.set_shader_input("ShadowMap", sun_shadow_target.depth_tex)
-            render.set_shader_input("shadowMVP", shadow_mvp)
-            render.set_shader_input("sunVector", sun_vector)
+            render.set_shader_inputs(
+                ShadowMap=sun_shadow_target.depth_tex,
+                shadowMVP=shadow_mvp,
+                sunVector=sun_vector)
 
             worker_handles.append((capture_rig, store_pta))
 

--- a/toolkit/bake_gi/display.py
+++ b/toolkit/bake_gi/display.py
@@ -70,9 +70,10 @@ class Application(ShowBase):
         shader = Shader.load(Shader.SL_GLSL, "resources/display.vert.glsl",  "resources/display.frag.glsl")
         render.set_shader(shader)
 
-        render.set_shader_input("ShadowMap", sun_shadow_target.depth_tex)
-        render.set_shader_input("shadowMVP", shadow_mvp)
-        render.set_shader_input("sunVector", sun_vector)
+        render.set_shader_inputs(
+            ShadowMap=sun_shadow_target.depth_tex,
+            shadowMVP=shadow_mvp,
+            sunVector=sun_vector)
 
         # Render spheres distributed over the mesh
         mesh_size = BAKE_MESH_END - BAKE_MESH_START


### PR DESCRIPTION
Multiple calls to `set_shader_input` create silly intermediate RenderStates that have to be garbage collected later on.  Panda (as of panda3d/panda3d@cfe810ace70a685441aef757ee7b0ec4680be105) has a new `set_shader_inputs` call that is more efficient at setting multiple inputs at the same time.  This patch lets the RenderPipeline takes advantage of that.  No dramatic advantages, but every bit helps.

I included some polyfill code to support older versions of Panda.