### PR TITLE
Fix mismatch of the name of task

### DIFF
--- a/rpcore/gui/pipe_viewer.py
+++ b/rpcore/gui/pipe_viewer.py
@@ -68,7 +68,7 @@ class PipeViewer(DraggableWindow):
     def toggle(self):
         """ Toggles the pipe viewer """
         if self._visible:
-            Globals.base.taskMgr.remove("UpdatePipeViewer")
+            Globals.base.taskMgr.remove("RP_GUI_UpdatePipeViewer")
             self.hide()
         else:
             Globals.base.taskMgr.add(self._update_task, "RP_GUI_UpdatePipeViewer")


### PR DESCRIPTION
Hello. I found that the names of task does not match in PipeViewer. This PR fixes it.