### PR TITLE
Fix error displaying buffer viewer

### DIFF
--- a/rpcore/util/display_shader_builder.py
+++ b/rpcore/util/display_shader_builder.py
@@ -71,6 +71,7 @@ class DisplayShaderBuilder(object):  # pylint: disable=too-few-public-methods
         # Build actual shader
         built = """
             #version 400
+            #extension GL_ARB_shading_language_420pack : enable
             #pragma include "render_pipeline_base.inc.glsl"
             in vec2 texcoord;
             out vec3 result;


### PR DESCRIPTION
The `binding` qualifier is not supported in GLSL 4.00, so the screen is littered with shader compilation errors when opening the buffer viewer, which apparently uses a shader with `#version 400`.  This remedies that by enabling the `GL_ARB_shading_language_420pack` extension.