### PR TITLE
Specify required OpenGL context version

### DIFF
--- a/config/panda3d-config.prc
+++ b/config/panda3d-config.prc
@@ -103,6 +103,9 @@ gl-force-fbo-color #f
 
 # ----------- OpenGL / Performance Settings ------------
 
+# Require OpenGL 4.3 at least, necessary for Intel drivers on Linux
+gl-version 4 3
+
 # Animations on the gpu. The default shader has to get adjusted to support this
 # feature before this option can be turned on.
 # hardware-animated-vertices #t

--- a/data/default_cubemap/filter.py
+++ b/data/default_cubemap/filter.py
@@ -42,6 +42,7 @@ class Application(ShowBase):
             gl-coordinate-system default
             notify-level-display error
             print-pipe-types #f
+            gl-version 4 3
         """)
 
         ShowBase.__init__(self)

--- a/data/film_grain/generate.py
+++ b/data/film_grain/generate.py
@@ -48,6 +48,7 @@ class Application(ShowBase):
             gl-coordinate-system default
             notify-level-display error
             print-pipe-types #f
+            gl-version 4 3
         """)
 
         ShowBase.__init__(self)

--- a/rpplugins/clouds/resources/precompute.py
+++ b/rpplugins/clouds/resources/precompute.py
@@ -41,6 +41,7 @@ class Application(ShowBase):
             gl-coordinate-system default
             notify-level-display error
             print-pipe-types #f
+            gl-version 4 3
         """)
 
         ShowBase.__init__(self)


### PR DESCRIPTION
Specifying a `gl-version` requirement of 3.2+ makes Panda3D request a core-only profile, which is not only good for performance but is required by some drivers (eg. Intel on Linux) to access the latest OpenGL features, such as compute shaders.

Fixes #79