### PR TITLE
shader: ensure RESTRICT is defined for all vendors

### DIFF
--- a/rpcore/shader/render_pipeline_base.inc.glsl
+++ b/rpcore/shader/render_pipeline_base.inc.glsl
@@ -100,10 +100,10 @@
 // https://devtalk.nvidia.com/default/topic/546817/restrict-keyword-crashes-glsl-compiler/
 // Also, intel seems to expect the keyword (correctly) *before* the image specifier,
 // in contrast to AMD, so we disable it on intel gpus, too.
-#if IS_NVIDIA || IS_INTEL
-    #define RESTRICT
-#else
+#if IS_AMD
     #define RESTRICT restrict
+#else
+    #define RESTRICT
 #endif
 
 // TODO:


### PR DESCRIPTION
This patch ensures that the restrict macro is defined for all graphics
vendors.

This fixes shader compilation errors when using Mesa3D, which reports
its vendor as X.org.