### PR TITLE
Fix incorrect definition of IS_AMD on NVIDIA hardware

### DIFF
--- a/rpcore/render_pipeline.py
+++ b/rpcore/render_pipeline.py
@@ -587,7 +587,7 @@ class RenderPipeline(RPObject):
         # Provide driver vendor as a define
         vendor = self._showbase.win.gsg.get_driver_vendor().lower()
         defines["IS_NVIDIA"] = "nvidia" in vendor
-        defines["IS_AMD"] = "ati" in vendor
+        defines["IS_AMD"] = vendor.startswith("ati")
         defines["IS_INTEL"] = "intel" in vendor
 
         defines["REFERENCE_MODE"] = self.settings["pipeline.reference_mode"]


### PR DESCRIPTION
Completely untested suggestion for fixing #103 by ignoring "ati" when it is in the middle of the string, since "ati" also occurs in the strings "NVIDIA Corporation", "Intel Corporation", "Microsoft Corporation" and "Imagination Technologies".

For reference, here is a list of vendor strings that are out there in the wild:
http://feedback.wildfiregames.com/report/opengl/feature/GL_VENDOR

Fixes #103