### PR TITLE
Python 3.8 support

### DIFF
--- a/rpcore/loader.py
+++ b/rpcore/loader.py
@@ -51,10 +51,10 @@ class timed_loading_operation(object):  # noqa # pylint: disable=invalid-name,to
             self.resource = ', '.join(self.resource)
 
     def __enter__(self):
-        self.start_time = time.clock()
+        self.start_time = time.process_time()
 
     def __exit__(self, *args):
-        duration = (time.clock() - self.start_time) * 1000.0
+        duration = (time.process_time() - self.start_time) * 1000.0
         if duration > 80.0 and timed_loading_operation.WARNING_COUNT < 5:
             RPObject.global_warn(
                 "RPLoader", "Loading '" + self.resource + "' took", round(duration, 2), "ms")

--- a/rpcore/render_pipeline.py
+++ b/rpcore/render_pipeline.py
@@ -189,7 +189,7 @@ class RenderPipeline(RPObject):
         # when we finished, so we can measure how long it took to render the
         # first frame (where the shaders are actually compiled)
         init_duration = (time.time() - start_time)
-        self._first_frame = time.clock()
+        self._first_frame = time.process_time()
         self.debug("Finished initialization in {:3.3f} s, first frame: {}".format(
             init_duration, Globals.clock.get_frame_count()))
 
@@ -567,7 +567,7 @@ class RenderPipeline(RPObject):
         update hook. """
         self.plugin_mgr.trigger_hook("post_render_update")
         if self._first_frame is not None:
-            duration = time.clock() - self._first_frame
+            duration = time.process_time() - self._first_frame
             self.debug("Took", round(duration, 3), "s until first frame")
             self._first_frame = None
         return task.cont

--- a/rpcore/util/generic.py
+++ b/rpcore/util/generic.py
@@ -90,10 +90,10 @@ class profile_cpu(object):  # noqa # pylint: disable=invalid-name,too-few-public
         self.name = name
 
     def __enter__(self):
-        self.start_time = time.clock()
+        self.start_time = time.process_time()
 
     def __exit__(self, *args):
-        duration = (time.clock() - self.start_time) * 1000.0
+        duration = (time.process_time() - self.start_time) * 1000.0
         print(self.name, "took", round(duration, 2), "ms ")
 
 

--- a/rplibs/yaml/__init__.py
+++ b/rplibs/yaml/__init__.py
@@ -25,7 +25,7 @@ def load_yaml_file(filename):
     """ This method is a wrapper arround yaml_load, and provides error checking """
 
     import time
-    start = time.clock()
+    start = time.process_time()
 
     try:
         with open(filename, "r") as handle:
@@ -39,7 +39,7 @@ def load_yaml_file(filename):
         RPObject.global_error("YAMLLoader", msg)
         raise Exception("Failed to load YAML file: Invalid syntax")
 
-    duration = (time.clock() - start) * 1000.0
+    duration = (time.process_time() - start) * 1000.0
 
     # Optionally print out profiling information
     # print("Took", round(duration, 2), "ms to load", filename)


### PR DESCRIPTION
Here https://docs.python.org/3/whatsnew/3.8.html we can read the following:
```The function time.clock() has been removed, after having been deprecated since Python 3.3: use time.perf_counter() or time.process_time() instead, depending on your requirements, to have well-defined behavior. (Contributed by Matthias Bussonnier in bpo-36895.)```

This PR replaces `time.clock()` with `time.process_time()`.